### PR TITLE
Give instructions to create and access ~/.pandoc without unhiding invisibles

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can [explore my working Pandoc folder here](https://github.com/iandol/dotpan
 
 `pandocomatic` uses a single configuration file normally stored at the root of the Pandoc data directory: `$HOME/.pandoc/pandocomatic.yaml`. A simplified [ sample `pandocomatic.yaml` is shared here](https://github.com/iandol/scrivomatic/blob/master/pandocomatic.yaml); this won't work without customisation, but it gives you an idea of how the pandocomatic styles work. The basic idea is you create a series of styles, and each style collects together a bunch of settings and configurations to produce a particular output. So I have `docx` style which is a basic Word conversion, but also a `docx-refs` which runs the bibliographic tools to generates a bibliography automatically.
 
-For the reset of the files in the Pandoc data directory: all custom Pandoc templates reside in `$HOME/.pandoc/templates`, and filters in `$HOME/.pandoc/filters`. For bibliographies, I symbolically link my Bibliography.bib into in `$HOME/.pandoc` and store my Journal style files in `$HOME/.pandoc/csl`. `pandocomatic` enables the use of pre– and post–processor scripts and these are stored in their own subfolders.
+For the rest of the files in the Pandoc data directory: all custom Pandoc templates reside in `$HOME/.pandoc/templates`, and filters in `$HOME/.pandoc/filters`. For bibliographies, I symbolically link my Bibliography.bib into in `$HOME/.pandoc` and store my Journal style files in `$HOME/.pandoc/csl`. `pandocomatic` enables the use of pre– and post–processor scripts and these are stored in their own subfolders.
 
 ## Writing in Scrivener ##
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,17 @@ To keep both Pandoc and Pandocomatic *up-to-date*, you can run the update comman
 
 ### Configuration ###
 
-The most important folder for this workflow is the Pandoc data directory: `$HOME/.pandoc` ($HOME is your user directory, for example `/Users/johndoe/`). Though not required, it is easiest to organise your templates, filters and other files there. It is a hidden folder by default, so you can use the terminal to manage it, or learn [how to unhide it first](https://www.google.com/search?q=unhide+folder+mac) if you prefer to use Finder.
+The most important folder for this workflow is the Pandoc data directory: `$HOME/.pandoc` ($HOME is your user directory, for example `/Users/johndoe/`). Though not required, it is easiest to organise your templates, filters and other files there.  To create your `$HOME/.pandoc` folder:
+
+```bash
+> mkdir ~/.pandoc
+```
+
+All folders starting with a `.` are a hidden by default, but you can open them in Finder in two ways: 1) using the shortcut <kbd>CMD</kbd>+<kbd>SHIFT</kbd>+<kbd>>G</kbd> and typing the path, in this case `~/.pandoc`; or 2) using the Terminal and typing:
+
+```bash
+> open ~/.pandoc
+```
 
 You can [explore my working Pandoc folder here](https://github.com/iandol/dotpandoc). It is comprised of a series of subfolders organised into the files Pandoc can use. You can *install* my Pandoc folder by [downloading it](https://github.com/iandol/dotpandoc/archive/master.zip) and unzipping it into your `$HOME/.pandoc`
 


### PR DESCRIPTION
My reasoning for the suggestions made are:

1. Unhiding files will show not only `~/.pandoc` folder but every existing hidden file and folder. If the user is unfamiliar with it all and changes or deletes the wrong folder, something may break. If the user knows this, she/he doesn't need instructions.
2. Opening hidden files and folders in Finder doesn't require unhiding them and one of the proposed methods doesn't even use the Terminal.
4. The uses it, but many instructions, including installing `pandoc` itself involve the Terminal already.
5. Installing `pandoc` doesn't create `~/.pandoc`, so having instructions may help less savvy users.

And one obvious but unrelated typo was corrected.